### PR TITLE
ubuntu-desktop with -no-install-recommends

### DIFF
--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -45,7 +45,8 @@ class virtualbox_x11 {
 
 class unity_desktop {
   package { "ubuntu-desktop":
-    ensure => present
+    ensure => present,
+    install_options => ['--no-install-recommends'],
   }
   file { 'lightdm.conf':
     require => Package['ubuntu-desktop'],


### PR DESCRIPTION
Passing install options to unity_desktop. This allows optional packages such as open-office to not be installed and keeps the box lightweight.
